### PR TITLE
Add support for a config file using .mjs extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,9 +83,15 @@ if (options.dir) {
 
 // Load the user's config
 const userConfigFilename = path.join(targetDirectory, 'doxicity.config.js');
+const userConfigModuleFilename = path.join(targetDirectory, 'doxicity.config.mjs');
+
 if (existsSync(userConfigFilename)) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const userConfig = (await import(userConfigFilename)).default as Partial<DoxicityConfig>;
+  config = merge(defaultConfig, userConfig);
+} else if (existsSync(userConfigModuleFilename)) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const userConfig = (await import(userConfigModuleFilename)).default as Partial<DoxicityConfig>;
   config = merge(defaultConfig, userConfig);
 } else {
   config = { ...defaultConfig };


### PR DESCRIPTION
Ran into this issue in a non-module repository. Using a .mjs extension stopped Node from yelling at me, but broke loading the configuration. 